### PR TITLE
[1.x] Update Currency.vue to work inside Replicators 

### DIFF
--- a/resources/js/Currency.vue
+++ b/resources/js/Currency.vue
@@ -11,7 +11,6 @@
 
 <script>
 import Inputmask from "inputmask";
-import Fieldtype from '../../../../statamic/cms/resources/js/components/fieldtypes/Fieldtype.vue';
     
 export default {
     mixins: [Fieldtype],

--- a/resources/js/Currency.vue
+++ b/resources/js/Currency.vue
@@ -11,7 +11,8 @@
 
 <script>
 import Inputmask from "inputmask";
-
+import Fieldtype from '../../../../statamic/cms/resources/js/components/fieldtypes/Fieldtype.vue';
+    
 export default {
     mixins: [Fieldtype],
     mounted() {
@@ -36,7 +37,7 @@ export default {
          * @returns {string}
          */
         id() {
-            return 'currency-input-' + this.meta.handle;
+            return 'currency-input-' + this.fieldId;
         },
         /**
          * Returns the symbol for the currency input.

--- a/resources/js/Currency.vue
+++ b/resources/js/Currency.vue
@@ -11,7 +11,7 @@
 
 <script>
 import Inputmask from "inputmask";
-    
+
 export default {
     mixins: [Fieldtype],
     mounted() {


### PR DESCRIPTION
This PR fixes #2 by mixing in and using the generated ID from Statamic's `Fieldtype.vue`. Not 100% sure, but I think that was maybe the original intent, based on the existing `mixins: [Fieldtype]` within `Currency.vue`? 

Regardless, tested this change locally to confirm it fixes that bug (when used inside of a Replicator field).