### PR TITLE
Feature: Store values as sub-units

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,11 @@
             "Doefom\\CurrencyFieldtype\\": "src"
         }
     },
+    "autoload-dev": {
+        "classmap": [
+            "tests"            
+        ]
+    },
     "extra": {
         "statamic": {
             "name": "Currency Fieldtype",

--- a/src/Augmentables/AugmentedCurrency.php
+++ b/src/Augmentables/AugmentedCurrency.php
@@ -48,7 +48,9 @@ class AugmentedCurrency extends AbstractAugmented
             'append',
             'group_separator',
             'radix_point',
-            'digits'
+            'digits',
+            'store_sub_units',
+            'sub_unit_factor',
         ];
     }
 
@@ -63,13 +65,25 @@ class AugmentedCurrency extends AbstractAugmented
     }
 
     /**
+     * Returns the value in primary units, taking into account sub-unit storage.
+     *
+     * @return mixed The value of the data.
+     */
+    public function displayValue()
+    {
+        return $this->usesSubUnitStorage() ?
+            $this->value() / $this->subUnitFactor() :
+            $this->value();
+    }
+
+    /**
      * Returns the formatted currency value.
      *
      * @return string The formatted currency value.
      */
     public function formatted()
     {
-        return $this->fmt->formatCurrency($this->value(), $this->iso());
+        return $this->fmt->formatCurrency($this->displayValue(), $this->iso());
     }
 
     /**
@@ -156,4 +170,24 @@ class AugmentedCurrency extends AbstractAugmented
         return $this->fmt->getAttribute(NumberFormatter::FRACTION_DIGITS);
     }
 
+    /**
+     * Determines if the value is stored in sub-units.
+     *
+     * @return bool True if the value should be stored in sub-units, false otherwise.
+     */
+    public function usesSubUnitStorage(): bool
+    {
+        return Arr::get($this->data->config, 'store_sub_units', false);
+    }
+
+    /**
+     * Returns the numeric code of the currency.
+     *
+     * @return int
+     */
+    public function subUnitFactor(): int
+    {
+        $currency = Currencies::getCurrency($this->iso());
+        return Arr::get($currency, 'sub_unit_factor', 100);
+    }
 }

--- a/src/Fieldtypes/CurrencyFieldtype.php
+++ b/src/Fieldtypes/CurrencyFieldtype.php
@@ -102,7 +102,7 @@ class CurrencyFieldtype extends Fieldtype
             ],
 
             'store_sub_units' => [
-                'display' => 'Sub Units',
+                'display' => 'Sub-Units',
                 'instructions' => 'Store values in their lowest sub-unit _(eg, USD is stored in cents)_.',
                 'type' => 'toggle',
                 'default' => false,

--- a/src/Utils/Currencies.php
+++ b/src/Utils/Currencies.php
@@ -24,7 +24,7 @@ class Currencies
     public static array $currencyList = [
         "USD" => ["name" => "US Dollar", "numeric_code" => "840"],
         "EUR" => ["name" => "Euro", "numeric_code" => "978"],
-        "JPY" => ["name" => "Yen", "numeric_code" => "392"],
+        "JPY" => ["name" => "Yen", "numeric_code" => "392", "sub_unit_factor" => 1],
         "GBP" => ["name" => "Pound Sterling", "numeric_code" => "826"],
         "AUD" => ["name" => "Australian Dollar", "numeric_code" => "036"],
         "CAD" => ["name" => "Canadian Dollar", "numeric_code" => "124"],
@@ -57,7 +57,6 @@ class Currencies
     public static function getSymbol(string $iso): string|null
     {
         collect(\Doefom\CurrencyFieldtype\Utils\Currencies::$currencyList)->filter(fn($item, $key) => collect(\Doefom\CurrencyFieldtype\Utils\Currencies::$temp)->has($key));
-
 
         $currency = self::getCurrency($iso);
         return Arr::get($currency, 'symbol');

--- a/tests/Feature/CurrencyFieldtypeTest.php
+++ b/tests/Feature/CurrencyFieldtypeTest.php
@@ -83,6 +83,11 @@ class CurrencyFieldtypeTest extends TestCase
         $this->assertEquals(1234.56, $this->augmented->value);
     }
 
+    public function test_augmented_display_value()
+    {
+        $this->assertEquals(1234.56, $this->augmented->display_value);
+    }
+
     public function test_augmented_formatted()
     {
         $this->assertEquals('$1,234.56', $this->augmented->formatted);

--- a/tests/Feature/SubunitStorageTest.php
+++ b/tests/Feature/SubunitStorageTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Feature;
+
+use Doefom\CurrencyFieldtype\Fieldtypes\CurrencyFieldtype;
+use Doefom\CurrencyFieldtype\Models\Currency;
+use Statamic\Facades\Site;
+use Statamic\Fields\Field;
+use Tests\TestCase;
+
+class SubunitStorageTest extends TestCase
+{
+    protected CurrencyFieldtype $currencyFieldtype;
+    protected Currency $augmented;
+
+    /**
+     * Set up a field of currency fieldtype with a value of 1234.56 and the following configuration:
+     * handle: price
+     * iso: USD
+     * subunits: true
+     * For NumberFormatter use the locale en_US.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Site::setCurrent('en_US');
+
+        $value = 123456;
+
+        // --------------------------------------------------------
+        // SET UP FIELDTYPE
+        // --------------------------------------------------------
+
+        $field = new Field('price', [
+            'iso' => 'USD',
+            'type' => 'currency',
+            'display' => 'Price',
+            'icon' => 'currency',
+            'listable' => 'hidden',
+            'instructions_position' => 'above',
+            'visibility' => 'visible',
+            'hide_display' => false,
+            'store_sub_units' => true,
+        ]);
+        $field->setValue($value);
+
+        $currencyFieldtype = new CurrencyFieldtype();
+        $currencyFieldtype->setField($field);
+
+        $this->currencyFieldtype = $currencyFieldtype;
+
+        // --------------------------------------------------------
+        // SET UP AUGMENTED INSTANCE
+        // --------------------------------------------------------
+
+        $this->augmented = $this->currencyFieldtype->augment($value);
+
+    }
+
+    public function test_pre_process()
+    {
+        $result = $this->currencyFieldtype->preProcess(123456);
+        $this->assertEquals('1,234.56', $result);
+    }
+
+    public function test_process()
+    {
+        $result = $this->currencyFieldtype->process('1,234.56');
+        $this->assertEquals(123456, $result);
+    }
+
+    public function test_pre_process_index()
+    {
+        $result = $this->currencyFieldtype->preProcessIndex(123456);
+        $this->assertEquals('$1,234.56', $result);
+    }
+
+    public function test_augmented_value()
+    {
+        $this->assertEquals(123456, $this->augmented->value);
+    }
+
+    public function test_augmented_display_value()
+    {
+        $this->assertEquals(1234.56, $this->augmented->display_value);
+    }
+
+    public function test_augmented_formatted()
+    {
+        $this->assertEquals('$1,234.56', $this->augmented->formatted);
+    }
+
+    public function test_augmented_formatted_no_symbol()
+    {
+        $this->assertEquals('1,234.56', $this->augmented->formattedNoSymbol);
+    }
+
+    public function test_augmented_iso()
+    {
+        $this->assertEquals('USD', $this->augmented->iso);
+    }
+
+    public function test_augmented_numeric_code()
+    {
+        $this->assertEquals('840', $this->augmented->numericCode);
+    }
+
+    public function test_augmented_symbol()
+    {
+        $this->assertEquals('$', $this->augmented->symbol);
+    }
+
+    public function test_augmented_append()
+    {
+        $this->assertFalse($this->augmented->append);
+    }
+
+    public function test_augmented_group_separator()
+    {
+        $this->assertEquals(',', $this->augmented->groupSeparator);
+    }
+
+    public function test_augmented_radix_point()
+    {
+        $this->assertEquals('.', $this->augmented->radixPoint);
+    }
+
+    public function test_augmented_digits()
+    {
+        $this->assertEquals(2, $this->augmented->digits);
+    }
+
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,14 @@
 <?php
 
-use \PHPUnit\Framework\TestCase as BaseTestCase;
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Orchestra\Testbench\Concerns\CreatesApplication;
 use Statamic\Providers\StatamicServiceProvider;
 
-class TestCase extends BaseTestCase
+abstract class TestCase extends BaseTestCase
 {
+    use CreatesApplication;
 
     protected function getPackageProviders($app)
     {
@@ -13,5 +17,4 @@ class TestCase extends BaseTestCase
             StatamicServiceProvider::class,
         ];
     }
-
 }


### PR DESCRIPTION
This PR adds the ability to toggle on a sub-unit storage setting in the fieldtype. When enabled, values are stored in the lowest common denominator—the sub-unit—of the selected currency. 

![image](https://github.com/doefom/currency-fieldtype/assets/13950848/e0202eb3-f9f4-4ca3-b2a8-c5a356b41e2b)

The "primary" or "common" currency doesn't have to have a sub-unit. For example, USD has cents but the Yen has no "cents" equivalent. In those situations, we can define a `sub_unit_factor` within `Currencies::currencyList` when needed, to override the default `sub_unit_factor` of 100. In the case of the Yen, that value is set to `1` so it can go unchanged.

Initially, I went down the rabbit hole of updating the Vue component, but that wasn't necessary and ended up becoming its own can of worms, due to the masking library that's used in that component. All of the accessor/mutator-like functionality happens server-side, mostly within `AugmentedCurrency` and `CurrencyFieldtype`. Check out those files and let me know what you think! If merged, this will close #1.