### PR TITLE
Bug: Augmentation breaks with a null value

### DIFF
--- a/src/Augmentables/AugmentedCurrency.php
+++ b/src/Augmentables/AugmentedCurrency.php
@@ -79,24 +79,28 @@ class AugmentedCurrency extends AbstractAugmented
     /**
      * Returns the formatted currency value.
      *
-     * @return string The formatted currency value.
+     * @return string|null The formatted currency value.
      */
     public function formatted()
     {
-        return $this->fmt->formatCurrency($this->displayValue(), $this->iso());
+        if( $this->hasNonNullValue() ){
+            return $this->fmt->formatCurrency($this->displayValue(), $this->iso());
+        } 
     }
 
     /**
      * Returns the formatted currency value without the symbol.
      *
-     * @return string The formatted currency value without the symbol.
+     * @return string|null The formatted currency value without the symbol.
      */
     public function formattedNoSymbol()
     {
-        $formatted = $this->formatted();
-        $symbol = $this->fmt->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
+        if( $this->hasNonNullValue() ){
+            $formatted = $this->formatted();
+            $symbol = $this->fmt->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
 
-        return trim(str_replace($symbol, '', $formatted));
+            return trim(str_replace($symbol, '', $formatted));
+        }
     }
 
     /**
@@ -189,5 +193,15 @@ class AugmentedCurrency extends AbstractAugmented
     {
         $currency = Currencies::getCurrency($this->iso());
         return Arr::get($currency, 'sub_unit_factor', 100);
+    }
+
+    /**
+     * Determines if the value is non-null.
+     *
+     * @return bool True if the value is anything other than null, false otherwise.
+     */
+    private function hasNonNullValue()
+    {
+        return ! is_null($this->value());
     }
 }

--- a/src/Models/Currency.php
+++ b/src/Models/Currency.php
@@ -11,10 +11,10 @@ class Currency implements Augmentable
 {
     use HasAugmentedInstance;
 
-    public float $value;
+    public float|null $value;
     public array $config;
 
-    public function __construct(float $value, array $config)
+    public function __construct(?float $value, array $config)
     {
         $this->value = $value;
         $this->config = $config;

--- a/tests/Feature/CurrencyFieldtypeTest.php
+++ b/tests/Feature/CurrencyFieldtypeTest.php
@@ -47,10 +47,8 @@ class CurrencyFieldtypeTest extends TestCase
         ]);
         $field->setValue($value);
 
-        $currencyFieldtype = new CurrencyFieldtype();
-        $currencyFieldtype->setField($field);
-
-        $this->currencyFieldtype = $currencyFieldtype;
+        $this->currencyFieldtype = new CurrencyFieldtype();
+        $this->currencyFieldtype->setField($field);
 
         // --------------------------------------------------------
         // SET UP AUGMENTED INSTANCE

--- a/tests/Feature/CurrencyFieldtypeWithNullValueTest.php
+++ b/tests/Feature/CurrencyFieldtypeWithNullValueTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Feature;
+
+use Doefom\CurrencyFieldtype\Fieldtypes\CurrencyFieldtype;
+use Doefom\CurrencyFieldtype\Models\Currency;
+use Statamic\Facades\Site;
+use Statamic\Fields\Field;
+use Tests\TestCase;
+
+class CurrencyFieldtypeWithNullValueTest extends TestCase
+{
+
+    protected CurrencyFieldtype $currencyFieldtype;
+    protected Currency $augmented;
+
+    /**
+     * Set up a field of currency fieldtype with a value of null and the following configuration:
+     * handle: price
+     * iso: USD
+     *
+     * For NumberFormatter use the locale en_US.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Site::setCurrent('en_US');
+
+        $value = null;
+
+        // --------------------------------------------------------
+        // SET UP FIELDTYPE
+        // --------------------------------------------------------
+
+        $field = new Field('price', [
+            'iso' => 'USD',
+            'type' => 'currency',
+            'display' => 'Price',
+            'icon' => 'currency',
+            'listable' => 'hidden',
+            'instructions_position' => 'above',
+            'visibility' => 'visible',
+            'hide_display' => false,
+        ]);
+        $field->setValue($value);
+
+        $this->currencyFieldtype = new CurrencyFieldtype();
+        $this->currencyFieldtype->setField($field);
+
+        // --------------------------------------------------------
+        // SET UP AUGMENTED INSTANCE
+        // --------------------------------------------------------
+
+        $this->augmented = $this->currencyFieldtype->augment($value);
+
+    }
+
+    public function test_pre_process()
+    {
+        $result = $this->currencyFieldtype->preProcess(null);
+        $this->assertNull($result);
+    }
+
+    public function test_process()
+    {
+        $result = $this->currencyFieldtype->process(null);
+        $this->assertNull($result);
+    }
+
+    public function test_pre_process_index()
+    {
+        $result = $this->currencyFieldtype->preProcessIndex(null);
+        $this->assertNull($result);
+    }
+
+    public function test_augmented_value()
+    {
+        $this->assertEquals(null, $this->augmented->value);
+    }
+
+    public function test_augmented_display_value()
+    {
+        $this->assertEquals(null, $this->augmented->display_value);
+    }
+
+    public function test_augmented_formatted()
+    {
+        $this->assertNull($this->augmented->formatted);
+    }
+
+    public function test_augmented_formatted_no_symbol()
+    {
+        $this->assertNull($this->augmented->formattedNoSymbol);
+    }
+
+    public function test_augmented_iso()
+    {
+        $this->assertEquals('USD', $this->augmented->iso);
+    }
+
+    public function test_augmented_numeric_code()
+    {
+        $this->assertEquals('840', $this->augmented->numericCode);
+    }
+
+    public function test_augmented_symbol()
+    {
+        $this->assertEquals('$', $this->augmented->symbol);
+    }
+
+    public function test_augmented_append()
+    {
+        $this->assertFalse($this->augmented->append);
+    }
+
+    public function test_augmented_group_separator()
+    {
+        $this->assertEquals(',', $this->augmented->groupSeparator);
+    }
+
+    public function test_augmented_radix_point()
+    {
+        $this->assertEquals('.', $this->augmented->radixPoint);
+    }
+
+    public function test_augmented_digits()
+    {
+        $this->assertEquals(2, $this->augmented->digits);
+    }
+
+}


### PR DESCRIPTION
This PR fixes #7 by allowing for null values in `Models/Currency` and adding a new `hasNonNullValue()` check, which is used by the two formatting methods within `Augmentables/AugmentedCurrency`. This approach allows the field & application to differentiate between `null` and `0` values.

For example, an event system where events have a ticket `price` that can potentially be free ($0) and could _**also**_ have a null/empty value (ie, if the price hasn't been determined or published yet). Front end would probably want/need to know when the price is just null (ie, pending), instead of an entered `0`. 

We can also leverage [the new `default_value` config](https://github.com/doefom/currency-fieldtype/pull/6), to help set this to zero, if that's what an application calls for. 

Let me know what you think of this approach!