### PR TITLE
[1.x] Feature: List view filtering for Currency fieldtype

### DIFF
--- a/src/Fieldtypes/CurrencyFieldtype.php
+++ b/src/Fieldtypes/CurrencyFieldtype.php
@@ -2,6 +2,7 @@
 
 namespace Doefom\CurrencyFieldtype\Fieldtypes;
 
+use Doefom\CurrencyFieldtype\Filters\CurrencyFilter;
 use Doefom\CurrencyFieldtype\Models\Currency;
 use Doefom\CurrencyFieldtype\Utils\Currencies;
 use Illuminate\Support\Facades\App;
@@ -207,4 +208,12 @@ class CurrencyFieldtype extends Fieldtype
         return Arr::get($this->field()->config(), 'store_sub_units', false);
     }
 
+    /**
+     * Sets the custom filter type used in list view filters.
+     * @return CurrencyFilter
+     */
+    public function filter()
+    {
+        return new CurrencyFilter($this);
+    }
 }

--- a/src/Fieldtypes/CurrencyFieldtype.php
+++ b/src/Fieldtypes/CurrencyFieldtype.php
@@ -202,7 +202,7 @@ class CurrencyFieldtype extends Fieldtype
      *
      * @return bool The sub-unit boolean of the currency.
      */
-    private function usesSubUnitStorage(): bool
+    public function usesSubUnitStorage(): bool
     {
         return Arr::get($this->field()->config(), 'store_sub_units', false);
     }

--- a/src/Filters/CurrencyFilter.php
+++ b/src/Filters/CurrencyFilter.php
@@ -2,7 +2,6 @@
 
 namespace Doefom\CurrencyFieldtype\Filters;
 
-use Statamic\Query\Scopes\Filters\Fields\FieldtypeFilter;
 use Statamic\Query\Scopes\Filters\Fields\Number as NumberFilter;
 
 class CurrencyFilter extends NumberFilter

--- a/src/Filters/CurrencyFilter.php
+++ b/src/Filters/CurrencyFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doefom\CurrencyFieldtype\Filters;
+
+use Statamic\Query\Scopes\Filters\Fields\FieldtypeFilter;
+use Statamic\Query\Scopes\Filters\Fields\Number as NumberFilter;
+
+class CurrencyFilter extends NumberFilter
+{
+    protected function valueFieldtype()
+    {
+        return 'currency';
+    }
+
+    public function apply($query, $handle, $values)
+    {
+    	if($this->fieldtype->usesSubUnitStorage()){
+    		$values['value'] *= 100;
+    	}
+
+    	return parent::apply($query, $handle, $values);
+    }
+}


### PR DESCRIPTION
As of v1.2.3, the `Currency` fieldtype doesn't override the `filter` method available via Statamic's `Fieldtype` class. Instead, it's using the default, which is just a standard filter intended for simple text comparisons/queries. That doesn't play nicely with the numeric values returned by the `Currency` fieldtype. Here's what that currently looks like, on a collection's list view in the CP:

### Before
![currency-before](https://github.com/doefom/currency-fieldtype/assets/13950848/2106ddde-8ab9-426e-9802-4128cd62ad28)

This PR introduces a new, custom filter that's specific to the `Currency` fieldtype, but inherits the majority of its functionality from Statamic's underlying number filter. That filter has all the basic nuts and bolts needed for numeric filtering—we just add a small check on top of the `apply` method, to account for subunit storage by updating the searched `value`, if/when it's enabled. Here's how things look, with this update applied:

### After
![currency-after](https://github.com/doefom/currency-fieldtype/assets/13950848/d69e37e3-5caf-428c-9ea1-a422d9d777e0)

Let me know if we need to tweak anything else, here—hope you're having a great week, Dominik!