### PR TITLE
Fix empty iso when using USD

### DIFF
--- a/src/Augmentables/AugmentedCurrency.php
+++ b/src/Augmentables/AugmentedCurrency.php
@@ -110,7 +110,7 @@ class AugmentedCurrency extends AbstractAugmented
      */
     public function iso(): string|null
     {
-        return Arr::get($this->data->config, 'iso');
+        return Arr::get($this->data->config, 'iso', Currencies::$fallbackCurrency);
     }
 
     /**

--- a/src/Fieldtypes/CurrencyFieldtype.php
+++ b/src/Fieldtypes/CurrencyFieldtype.php
@@ -102,7 +102,7 @@ class CurrencyFieldtype extends Fieldtype
                 'display' => 'Currency',
                 'instructions' => 'Select which currency you want to use for the field.',
                 'type' => 'select',
-                'default' => 'USD',
+                'default' => Currencies::$fallbackCurrency,
                 'options' => collect(Currencies::$currencyList)
                     ->map(fn($item, $key) => Arr::get($item, 'name') . " ($key)")
                     ->sortBy(fn($val) => $val),
@@ -168,7 +168,7 @@ class CurrencyFieldtype extends Fieldtype
      */
     private function getIso(): string
     {
-        return Arr::get($this->field()->config(), 'iso', 'USD');
+        return Arr::get($this->field()->config(), 'iso', Currencies::$fallbackCurrency);
     }
 
     private function convertToStorage($value)

--- a/src/Utils/Currencies.php
+++ b/src/Utils/Currencies.php
@@ -8,6 +8,10 @@ use Statamic\Support\Arr;
 
 class Currencies
 {
+    /**
+     * The fallback currency to use when not specified.
+     */
+    public static string $fallbackCurrency = "USD";
 
     /**
      * Get the currency details by its ISO identifier ("EUR", "USD", etc.).


### PR DESCRIPTION
As described in #14, using `USD` as currency in Statamic 5 will result in an error since field config keys matching the defaults are now removed, but the addon still expects the `USD` value to be present. This PR makes sure the fallback/default currency `USD` is properly applied everywhere.

I didn't manage to get the tests running locally — would be nice if you could check real quick if tests are passing for you.